### PR TITLE
fix: error of update link due to branche rename

### DIFF
--- a/package.json
+++ b/package.json
@@ -8,7 +8,8 @@
     "addonRef": "BetterNotes",
     "prefsPrefix": "extensions.zotero.Knowledge4Zotero",
     "addonInstance": "BetterNotes",
-    "updaterdf": "https://raw.githubusercontent.com/windingwind/zotero-better-notes/bootstrap/update.json"
+    "releasepage": "https://github.com/windingwind/zotero-better-notes/releases/latest/download/zotero-better-notes.xpi",
+    "updaterdf": "https://raw.githubusercontent.com/windingwind/zotero-better-notes/master/update.json"
   },
   "main": "src/index.ts",
   "scripts": {


### PR DESCRIPTION

![image](https://github.com/windingwind/zotero-better-notes/assets/44738481/43722736-598a-4afe-b964-b6f37afc4a87)

需要重新发布一个版本
建议再新建一个 bootstrap 分支，把 update.json 放进去并指向 master 分支