### PR TITLE
Make updateTags defer to ExportMDFileHeaderV2

### DIFF
--- a/src/modules/template/preview.ts
+++ b/src/modules/template/preview.ts
@@ -56,12 +56,6 @@ async function renderTemplatePreview(
         libraryID: data.libraryID,
         itemKey: data.key,
       });
-      if (getPref("sync.updateTags")) {
-        const tags = data.getTags();
-        if (tags.length) {
-          header.tags = tags.map((tag) => tag.tag);
-        }
-      }
       html = `<pre>${YAML.stringify(header, 10)}</pre>`;
     }
   } else if (templateName.includes("ExportMDFileContent")) {

--- a/src/utils/convert.ts
+++ b/src/utils/convert.ts
@@ -113,6 +113,9 @@ async function note2md(
         if (key.startsWith("$") && key in header) {
           // generated header overwrites cached header
           continue;
+        } else if (key == "tags" && getPref("sync.updateTags")) {
+          // overwrite tags with updated ExportMDFileHeaderV2
+          continue;
         } else {
           // otherwise do not overwrite
           header[key] = cachedHeader[key];
@@ -126,13 +129,6 @@ async function note2md(
       $libraryID: noteItem.libraryID,
       $itemKey: noteItem.key,
     });
-    if (getPref("sync.updateTags")) {
-      const tags = noteItem.getTags();
-      header.tags = [];
-      if (tags.length) {
-        tags.forEach((tag) => header.tags.push(tag.tag));
-      }
-    }
     const yamlFrontMatter = `---\n${YAML.stringify(header, 10)}\n---`;
     md = `${yamlFrontMatter}\n${md}`;
   }


### PR DESCRIPTION
I would like to propose a change to the updateTags feature added in #1024. I prefer to pull tags from the parent item rather than the note, as well as transform tags to standardize them with kebab case. Here's an example:
```
${{
  let header = {};
  header.tags = noteItem.parentItem.getTags().map((_t) => _t.tag.replace(" ", "-").toLowerCase());
  header.parent = noteItem.parentItem
    ? noteItem.parentItem.getField("title")
    : "";
  header.collections = (
    await Zotero.Collections.getCollectionsContainingItems([
      (noteItem.parentItem || noteItem).id,
    ])
  ).map((c) => c.name);
  return JSON.stringify(header);
}}$
```

This change reverts to the old behavior of generating tags in ExportMDFileHeaderV2 but retains the auto-update functionality.