### PR TITLE
add disabled checkbox for ctrl+/

### DIFF
--- a/addon/chrome/content/preferences.xhtml
+++ b/addon/chrome/content/preferences.xhtml
@@ -65,6 +65,12 @@
     preference="__prefsPrefix__.editor.useMagicKey"
   />
   <checkbox
+    data-l10n-id="editor-defaultMagicKey"
+    native="true"
+    preference="__prefsPrefix__.editor.defaultMagicKey"
+    disabled="true"
+  />
+  <checkbox
     data-l10n-id="editor-useMarkdownPaste"
     native="true"
     preference="__prefsPrefix__.editor.useMarkdownPaste"

--- a/addon/locale/en-US/preferences.ftl
+++ b/addon/locale/en-US/preferences.ftl
@@ -22,11 +22,16 @@ editor-noteLinkPreview-disable =
     .label = Never
 editor-useMagicKey = 
     .label = Use magic key "/" to show command palette
+editor-defaultMagicKey = 
+    .label = Use { PLATFORM() ->
+        [macos] ⌘
+       *[other] Ctrl
+    } + "/" to show command palette
 editor-useMarkdownPaste = 
     .label = Use enhanced markdown paste
 editor-pinTable-label = Pin table's
 editor-pinTableLeft =
-    .label = Fist column
+    .label = First column
 editor-pinTableTop =
     .label = First row when scrolling
 

--- a/addon/locale/it-IT/preferences.ftl
+++ b/addon/locale/it-IT/preferences.ftl
@@ -22,11 +22,16 @@ editor-noteLinkPreview-disable =
     .label = Never
 editor-useMagicKey = 
     .label = Usa il tasto magico "/" per mostrare il pannello dei comandi
+editor-defaultMagicKey = 
+    .label = Usa il tasto { PLATFORM() ->
+        [macos] ⌘
+       *[other] Ctrl
+    } + "/" per mostrare il pannello dei comandi
 editor-useMarkdownPaste = 
     .label = Usa l'incolla markdown avanzato
 editor-pinTable-label = Pin table's
 editor-pinTableLeft =
-    .label = Fist column
+    .label = First column
 editor-pinTableTop =
     .label = First row when scrolling
 

--- a/addon/locale/ru-RU/preferences.ftl
+++ b/addon/locale/ru-RU/preferences.ftl
@@ -22,11 +22,16 @@ editor-noteLinkPreview-disable =
     .label = Never
 editor-useMagicKey =
     .label = Использовать магическую клавишу "/" для отображения панели команд
+editor-defaultMagicKey = 
+    .label = Использовать клавишу { PLATFORM() ->
+        [macos] ⌘
+       *[other] Ctrl
+    } + "/" для отображения панели команд
 editor-useMarkdownPaste = 
     .label = Использовать расширенное вставление Markdown
 editor-pinTable-label = Pin table's
 editor-pinTableLeft =
-    .label = Fist column
+    .label = First column
 editor-pinTableTop =
     .label = First row when scrolling
 

--- a/addon/locale/tr-TR/preferences.ftl
+++ b/addon/locale/tr-TR/preferences.ftl
@@ -22,11 +22,16 @@ editor-noteLinkPreview-disable =
     .label = Never
 editor-useMagicKey =
     .label = Komut panelini göstermek için sihirli tuş "/" kullan
+editor-defaultMagicKey = 
+    .label = Komut panelini göstermek için { PLATFORM() ->
+        [macos] ⌘
+       *[other] Ctrl
+    } + "/" kullan
 editor-useMarkdownPaste =
     .label = Gelişmiş markdown yapıştırma kullan
 editor-pinTable-label = Pin table's
 editor-pinTableLeft =
-    .label = Fist column
+    .label = First column
 editor-pinTableTop =
     .label = First row when scrolling
 

--- a/addon/locale/zh-CN/preferences.ftl
+++ b/addon/locale/zh-CN/preferences.ftl
@@ -22,13 +22,18 @@ editor-noteLinkPreview-disable =
     .label = 从不
 editor-useMagicKey =
     .label = 使用魔法键 "/" 显示命令面板
+editor-defaultMagicKey = 
+    .label = 使用 { PLATFORM() ->
+        [macos] ⌘
+       *[other] Ctrl
+    } + "/" 显示命令面板
 editor-useMarkdownPaste = 
     .label = 使用增强的Markdown粘贴
-editor-pinTable-label = Pin table's
+editor-pinTable-label = 鼠标滚动时固定表格的
 editor-pinTableLeft =
-    .label = Fist column
+    .label = 首列
 editor-pinTableTop =
-    .label = First row when scrolling
+    .label = 首行
 
 sync-title = 同步
 sync-period-label = 自动同步周期 (秒)

--- a/addon/prefs.js
+++ b/addon/prefs.js
@@ -11,6 +11,7 @@ pref("__prefsPrefix__.workspace.outline.keepLinks", true);
 
 pref("__prefsPrefix__.editor.noteLinkPreviewType", "hover");
 pref("__prefsPrefix__.editor.useMagicKey", true);
+pref("__prefsPrefix__.editor.defaultMagicKey", true);
 pref("__prefsPrefix__.editor.useMarkdownPaste", true);
 pref("__prefsPrefix__.editor.pinTableLeft", true);
 pref("__prefsPrefix__.editor.pinTableTop", true);


### PR DESCRIPTION
- Add `ctrl/cmd` + `/` in the setting panel as a prompt for shortcut keys to call the command panel. (default: disabled)
- fix typos