### PR TITLE
add: support for exporting multiple notes to LaTeX

### DIFF
--- a/addon/locale/en-US/addon.ftl
+++ b/addon/locale/en-US/addon.ftl
@@ -10,6 +10,8 @@ menuAddNote-newTemplateStandaloneNote = New Standalone Note from Template
 menuAddNote-newTemplateItemNote = New Item Note from Template
 menuAddNote-importMD = Import MarkDown File as Note
 
+menuItem-exportLaTeX = Export Notes to LaTeX
+
 menuAddReaderNote-newTemplateNote = New Item Note from Template
 
 menuEditor-resizeImage = Resize Image

--- a/addon/locale/it-IT/addon.ftl
+++ b/addon/locale/it-IT/addon.ftl
@@ -10,6 +10,8 @@ menuAddNote-newTemplateStandaloneNote = Nuova nota indipendente da template
 menuAddNote-newTemplateItemNote = Nuova nota dell'elemento da template
 menuAddNote-importMD = Importa file MarkDown come nota
 
+menuItem-exportLaTeX = Esporta note in LaTeX
+
 menuAddReaderNote-newTemplateNote = Nuova nota dell'elemento da template
 
 menuEditor-resizeImage = Ridimensiona immagine

--- a/addon/locale/ru-RU/addon.ftl
+++ b/addon/locale/ru-RU/addon.ftl
@@ -10,6 +10,8 @@ menuAddNote-newTemplateStandaloneNote=Новая отдельная Заметк
 menuAddNote-newTemplateItemNote=Новая элементная Заметка из шаблона
 menuAddNote-importMD = Импорт файла MarkDown в качестве примечания
 
+menuItem-exportLaTeX = Экспорт заметок в LaTeX
+
 menuAddReaderNote-newTemplateNote=Новая элементная Заметка из шаблона
 
 menuEditor-resizeImage=Изменить размер изображения

--- a/addon/locale/tr-TR/addon.ftl
+++ b/addon/locale/tr-TR/addon.ftl
@@ -10,6 +10,8 @@ menuAddNote-newTemplateStandaloneNote = Şablondan Yeni Bağımsız Not
 menuAddNote-newTemplateItemNote = Şablondan Yeni Eser Notu
 menuAddNote-importMD = Markdown Dosyasını Not Olarak İçe Aktar
 
+menuItem-exportLaTeX = Notları LaTeX olarak dışa aktar
+
 menuAddReaderNote-newTemplateNote = Şablondan Yeni Eser Notu
 
 menuEditor-resizeImage = Resmi Boyutlandır

--- a/addon/locale/zh-CN/addon.ftl
+++ b/addon/locale/zh-CN/addon.ftl
@@ -10,6 +10,8 @@ menuAddNote-newTemplateStandaloneNote=从模板新建独立笔记
 menuAddNote-newTemplateItemNote=从模板新建条目子笔记
 menuAddNote-importMD = 导入MarkDown为笔记
 
+menuItem-exportLaTeX = 导出笔记为LaTeX
+
 menuAddReaderNote-newTemplateNote=从模板新建条目子笔记
 
 menuEditor-resizeImage=缩放图片

--- a/src/api.ts
+++ b/src/api.ts
@@ -18,7 +18,7 @@ import { saveDocx } from "./modules/export/docx";
 import { saveFreeMind } from "./modules/export/freemind";
 import { saveMD, syncMDBatch } from "./modules/export/markdown";
 import { savePDF } from "./modules/export/pdf";
-import { saveLatex } from "./modules/export/latex";
+import { saveLatex, saveMultipleLatex } from "./modules/export/latex";
 import { fromMD } from "./modules/import/markdown";
 import {
   isSyncNote,
@@ -146,6 +146,7 @@ const $export = {
   saveDocx,
   savePDF,
   saveLatex,
+  saveMultipleLatex,
 };
 
 const $import = {

--- a/src/modules/export/latex.ts
+++ b/src/modules/export/latex.ts
@@ -21,12 +21,115 @@ export async function saveLatex(
     );
     await IOUtils.makeDirectory(attachmentsDir);
   }
-  await Zotero.File.putContentsAsync(
-    filename,
-    await addon.api.convert.note2latex(noteItem, dir, options),
+  const [latexContent, bibString] = await addon.api.convert.note2latex(
+    noteItem,
+    dir,
+    options,
   );
+  await Zotero.File.putContentsAsync(filename, latexContent);
 
   showHintWithLink(`Note Saved to ${filename}`, "Show in Folder", (ev) => {
     Zotero.File.reveal(filename);
   });
+
+  if (bibString && bibString.length > 0) {
+    const raw = await new ztoolkit.FilePicker(
+      `${Zotero.getString("fileInterface.export")} Bibtex File`,
+      "save",
+      [["Bibtex File(*.bib)", "*.bib"]],
+      `notegeneration.bib`,
+    ).open();
+    if (!raw) {
+      Zotero.debug("[Bib Export] Bib file export canceled.");
+      return;
+    }
+    const bibfilename = formatPath(raw, ".bib");
+    await Zotero.File.putContentsAsync(bibfilename, bibString);
+    showHintWithLink(
+      `Bibliographic Saved to ${bibfilename}`,
+      "Show in Folder",
+      (ev) => {
+        Zotero.File.reveal(bibfilename);
+      },
+    );
+  }
+}
+
+export async function saveMultipleLatex() {
+  const inputItems = Zotero.getMainWindow().ZoteroPane.getSelectedItems();
+
+  const noteIds = [];
+  for (const item of inputItems) {
+    if (item.isNote()) {
+      noteIds.push(item.id);
+    } else if (item.getNotes().length > 0) {
+      item.getNotes().forEach((noteId) => noteIds.push(noteId));
+    }
+  }
+  ztoolkit.log(noteIds);
+
+  const raw = await new ztoolkit.FilePicker(
+    `${Zotero.getString("fileInterface.export")} Latex File`,
+    "save",
+    [["Latex File(*.tex)", "*.tex"]],
+    `export-multiple-notes-to-latex.tex`,
+  ).open();
+  if (!raw) return;
+  const filename = formatPath(raw, ".tex");
+
+  const noteItems = noteIds.map((id) => Zotero.Items.get(id));
+  const dir = jointPath(...PathUtils.split(formatPath(filename)).slice(0, -1));
+  await IOUtils.makeDirectory(dir);
+  const hasImage = noteItems.some((item) => item.getNote().includes("<img"));
+  if (hasImage) {
+    const attachmentsDir = jointPath(
+      dir,
+      getPref("syncAttachmentFolder") as string,
+    );
+    await IOUtils.makeDirectory(attachmentsDir);
+  }
+  let latexContent = "";
+  let bibString = "";
+  const separatedString = "\n\n";
+  for (const noteItem of noteItems) {
+    const [latexContent_, bibString_] = await addon.api.convert.note2latex(
+      noteItem,
+      dir,
+      {},
+    );
+    latexContent += latexContent_;
+    latexContent += separatedString;
+    if (bibString_.length > 0) {
+      bibString += bibString_;
+      bibString += separatedString;
+    }
+  }
+
+  await Zotero.File.putContentsAsync(filename, latexContent);
+
+  showHintWithLink(`Note Saved to ${filename}`, "Show in Folder", (ev) => {
+    Zotero.File.reveal(filename);
+  });
+
+  if (bibString.length > 0) {
+    const raw = await new ztoolkit.FilePicker(
+      `${Zotero.getString("fileInterface.export")} Bibtex File`,
+      "save",
+      [["Bibtex File(*.bib)", "*.bib"]],
+      `notegeneration.bib`,
+    ).open();
+    if (!raw) {
+      Zotero.debug("[Bib Export] Bib file export canceled.");
+      return;
+    }
+    const bibfilename = formatPath(raw, ".bib");
+    await Zotero.File.putContentsAsync(bibfilename, bibString);
+    showHintWithLink(
+      `Bibliographic Saved to ${bibfilename}`,
+      "Show in Folder",
+      (ev) => {
+        Zotero.File.reveal(bibfilename);
+      },
+    );
+  }
 }

--- a/src/modules/menu.ts
+++ b/src/modules/menu.ts
@@ -133,4 +133,12 @@ export function registerMenus(win: _ZoteroTypes.MainWindow) {
     icon: `chrome://${config.addonRef}/content/icons/favicon.png`,
     commandListener: () => addon.hooks.onShowUserGuide(win, true),
   });
+
+  ztoolkit.Menu.register("item", {
+    tag: "menuitem",
+    id: "zotero-itemmenu-exportLaTeX",
+    label: getString("menuItem-exportLaTeX"),
+    icon: `chrome://${config.addonRef}/content/icons/favicon.png`,
+    commandListener: () => addon.api.$export.saveMultipleLatex(),
+  });
 }

--- a/src/modules/template/preview.ts
+++ b/src/modules/template/preview.ts
@@ -80,7 +80,7 @@ async function renderTemplatePreview(
       if (!data) {
         html = messages.noNoteItem;
       } else {
-        const latexContent = await addon.api.convert.note2latex(
+        const [latexContent, bibString] = await addon.api.convert.note2latex(
           data,
           Zotero.getTempDirectory().path,
           { withYAMLHeader: false, skipSavingImages: true, keepNoteLink: true },


### PR DESCRIPTION
I have add the feature of exporting multiple notes to LaTeX (fix: #1378). The use is as follows, but I'm not sure if this is a reasonable implementation.

![exportMultipleLaTeX](https://github.com/user-attachments/assets/49af4a04-9510-4617-a2bf-c0329126c6e2)
