### PR TITLE
Add info on note synchronization

### DIFF
--- a/README.md
+++ b/README.md
@@ -195,7 +195,7 @@ To set up auto-sync, click `Set Auto-Sync` the first time you export your note. 
 
 Any changes made to your note or its corresponding Markdown file will be automatically synced. This feature makes it easy to keep all of your notes up to date and in one place.
 
-> 💡 Note: The note being edited will be synced after the editor is closed.
+> 💡 Note: Synchronisation takes place once the editor is closed and after the period of time you set in the `Auto-sync period` preference.
 
 ### Note Export
 


### PR DESCRIPTION
The info in the guide is not sufficient to understand the setting. Cf. Bug #1393 (I thought I had a bug because I was using Emacs).

I think adding this bit of information will help users make sense of the feature and not worry if the synchronization does not take place instantaneously.