### PR TITLE
fix incorrect deletion of the end character

### DIFF
--- a/src/extras/editor/magicKey.ts
+++ b/src/extras/editor/magicKey.ts
@@ -611,9 +611,13 @@ class PluginState {
 
   removeInputSlash(state: EditorState) {
     const { $from } = state.selection;
+    const { parent } = $from;
+    const text = parent.textContent;
     const { pos } = $from;
-    const tr = state.tr.delete(pos - 1, pos);
-    _currentEditorInstance._editorCore.view.dispatch(tr);
+    if (text.endsWith("/") && !text.endsWith("//")) {
+      const tr = state.tr.delete(pos - 1, pos);
+      _currentEditorInstance._editorCore.view.dispatch(tr);
+    }
   }
 }
 

--- a/src/extras/editor/magicKey.ts
+++ b/src/extras/editor/magicKey.ts
@@ -481,7 +481,9 @@ class PluginState {
         this._closePopup();
       } else if (event.key === "z" && (event.ctrlKey || event.metaKey)) {
         this._closePopup();
-        this.removeInputSlash(state);
+        if (this.options.enable) {
+          this.removeInputSlash(state);
+        }
       }
     });
 
@@ -587,8 +589,10 @@ class PluginState {
     if (!command) {
       return;
     }
-    // Remove the current input `/`
-    this.removeInputSlash(state);
+    if (this.options.enable) {
+      // Remove the current input `/`
+      this.removeInputSlash(state);
+    }
 
     const newState = _currentEditorInstance._editorCore.view.state;
 


### PR DESCRIPTION
当前BNotes默认启用 `Ctrl/Meta+/` 作为MagicKey，并将 `/` 作为MagicKey设置为可选项。
现有版本如果使用 `Ctrl+/` 调用设置面板，则选择命令或 `Ctrl+z` 退出后，会默认删去最后一个字符。

此PR实现了：1. 如果禁用 `/` 作为MagicKey的设置项，则不删除任何字符；2. 如果启用 `/` 作为MagicKey，则输入 `/` 调用设置面板时，完成或退出后删除 / ，如果使用 `Ctrl+/` 调用设置面板，完成或退出后不删除字符（通过检测字符是否以/结尾）