### PR TITLE
add: support for ${filename} in specifying attachment folder (#356)

### DIFF
--- a/addon/chrome/content/preferences.xhtml
+++ b/addon/chrome/content/preferences.xhtml
@@ -120,6 +120,10 @@
       preference="__prefsPrefix__.syncAttachmentFolder"
     ></html:input>
   </hbox>
+  <label
+    data-l10n-id="sync-attachmentFolder-hint"
+    style="opacity: 0.5;"
+  ></label>
   <hbox align="center">
     <button
       onclick="Zotero.__addonInstance__.hooks.onShowSyncManager()"

--- a/addon/locale/en-US/preferences.ftl
+++ b/addon/locale/en-US/preferences.ftl
@@ -38,6 +38,7 @@ editor-pinTableTop =
 sync-title = Sync
 sync-period-label = Auto-sync period (seconds)
 sync-attachmentFolder-label = Attachment folder
+sync-attachmentFolder-hint = (`&#36;&#123;filename&#125;` representing for current filename.)
 sync-manager =
     .label = Open Sync Manager
 template-title = Template

--- a/addon/locale/it-IT/preferences.ftl
+++ b/addon/locale/it-IT/preferences.ftl
@@ -38,6 +38,7 @@ editor-pinTableTop =
 sync-title = Sincronizzazione
 sync-period-label = Intervallo della sincronizzazione automatica (secondi)
 sync-attachmentFolder-label = Cartella degli allegati
+sync-attachmentFolder-hint = (`&#36;&#123;filename&#125;` rappresenta il nome del file attuale.)
 sync-manager =
     .label = Apri Manager di sincronizzazione
 template-title = Template

--- a/addon/locale/ru-RU/preferences.ftl
+++ b/addon/locale/ru-RU/preferences.ftl
@@ -38,6 +38,7 @@ editor-pinTableTop =
 sync-title = Синк
 sync-period-label = Авто-синк период (сек)
 sync-attachmentFolder-label = Attachment folder
+sync-attachmentFolder-hint = (`&#36;&#123;filename&#125;` репрезентує ім’я чинного файлу.)
 sync-manager =
     .label = Открыть Синк менеджер
 template-title = Шаблон

--- a/addon/locale/tr-TR/preferences.ftl
+++ b/addon/locale/tr-TR/preferences.ftl
@@ -38,6 +38,7 @@ editor-pinTableTop =
 sync-title = Eşitle
 sync-period-label = Otomatik Eşitleme Sıklığı (saniye)
 sync-attachmentFolder-label = Ek Klasörü
+sync-attachmentFolder-hint = (`&#36;&#123;filename&#125;` en son dosya isimlerini belirtmektedir.)
 sync-manager =
     .label = Eşitleme Yöneticisini Aç
 template-title = Şablon

--- a/addon/locale/zh-CN/preferences.ftl
+++ b/addon/locale/zh-CN/preferences.ftl
@@ -38,6 +38,7 @@ editor-pinTableTop =
 sync-title = 同步
 sync-period-label = 自动同步周期 (秒)
 sync-attachmentFolder-label = 附件文件夹
+sync-attachmentFolder-hint = (其中 `&#36;&#123;filename&#125;` 表示当前文件名)
 sync-manager =
     .label = 打开同步管理器
 template-title = 模板

--- a/src/modules/export/latex.ts
+++ b/src/modules/export/latex.ts
@@ -3,32 +3,25 @@ import { getPref } from "../../utils/prefs";
 import { formatPath, jointPath } from "../../utils/str";
 
 export async function saveLatex(
-  filename: string,
+  filePath: string,
   noteId: number,
   options: {
     keepNoteLink?: boolean;
   } = {},
 ) {
   const noteItem = Zotero.Items.get(noteId);
-  const dir = jointPath(...PathUtils.split(formatPath(filename)).slice(0, -1));
+  const filename = PathUtils.split(filePath).pop()
+  const dir = jointPath(...PathUtils.split(formatPath(filePath)).slice(0, -1));
   await IOUtils.makeDirectory(dir);
-  const hasImage = noteItem.getNote().includes("<img");
-  if (hasImage) {
-    const attachmentsDir = jointPath(
-      dir,
-      getPref("syncAttachmentFolder") as string,
-    );
-    await IOUtils.makeDirectory(attachmentsDir);
-  }
   const [latexContent, bibString] = await addon.api.convert.note2latex(
     noteItem,
     dir,
-    options,
+    {...options, filename: filename},
   );
-  await Zotero.File.putContentsAsync(filename, latexContent);
+  await Zotero.File.putContentsAsync(filePath, latexContent);
 
-  showHintWithLink(`Note Saved to ${filename}`, "Show in Folder", (ev) => {
-    Zotero.File.reveal(filename);
+  showHintWithLink(`Note Saved to ${filePath}`, "Show in Folder", (ev) => {
+    Zotero.File.reveal(filePath);
   });
 
   if (bibString && bibString.length > 0) {
@@ -54,18 +47,12 @@ export async function saveLatex(
   }
 }
 
-export async function saveMergedLatex(filename: string, noteIds: number[]) {
+export async function saveMergedLatex(filePath: string, noteIds: number[]) {
   const noteItems = noteIds.map((noteId) => Zotero.Items.get(noteId));
-  const dir = jointPath(...PathUtils.split(formatPath(filename)).slice(0, -1));
+  const filename = PathUtils.split(filePath).pop()
+  const dir = jointPath(...PathUtils.split(formatPath(filePath)).slice(0, -1));
   await IOUtils.makeDirectory(dir);
-  const hasImage = noteItems.some((item) => item.getNote().includes("<img"));
-  if (hasImage) {
-    const attachmentsDir = jointPath(
-      dir,
-      getPref("syncAttachmentFolder") as string,
-    );
-    await IOUtils.makeDirectory(attachmentsDir);
-  }
+  
   let latexContent = "";
   let bibString = "";
   const separatedString = "\n\n";
@@ -73,7 +60,7 @@ export async function saveMergedLatex(filename: string, noteIds: number[]) {
     const [latexContent_, bibString_] = await addon.api.convert.note2latex(
       noteItem,
       dir,
-      {},
+      {filename: filename},
     );
     latexContent += latexContent_;
     latexContent += separatedString;
@@ -83,10 +70,10 @@ export async function saveMergedLatex(filename: string, noteIds: number[]) {
     }
   }
 
-  await Zotero.File.putContentsAsync(filename, latexContent);
+  await Zotero.File.putContentsAsync(filePath, latexContent);
 
-  showHintWithLink(`Note Saved to ${filename}`, "Show in Folder", (ev) => {
-    Zotero.File.reveal(filename);
+  showHintWithLink(`Note Saved to ${filePath}`, "Show in Folder", (ev) => {
+    Zotero.File.reveal(filePath);
   });
 
   if (bibString.length > 0) {

--- a/src/utils/convert.ts
+++ b/src/utils/convert.ts
@@ -136,10 +136,23 @@ async function note2md(
     withYAMLHeader?: boolean;
     cachedYAMLHeader?: Record<string, any>;
     skipSavingImages?: boolean;
+    filename?: string;
   } = {},
 ) {
   const noteStatus = addon.api.sync.getNoteStatus(noteItem.id)!;
   const rehype = await note2rehype(noteStatus.content);
+
+  var attachmentFolder = getPref("syncAttachmentFolder") as string
+  if (options.filename) {
+    var oldDir = new String(attachmentFolder)
+    attachmentFolder = oldDir.replace(/\${filename}/g, options.filename.replace(/\.md$/gm, '')).valueOf()  // substitute ${filename} & trim '.md'
+  }
+
+  const hasImage = noteItem.getNote().includes("<img")
+  if (hasImage) {
+    await IOUtils.makeDirectory(jointPath(dir, attachmentFolder));
+  }
+
   processN2MRehypeHighlightNodes(
     getN2MRehypeHighlightNodes(rehype as HRoot),
     NodeMode.direct,
@@ -156,7 +169,7 @@ async function note2md(
   await processN2MRehypeImageNodes(
     getN2MRehypeImageNodes(rehype),
     noteItem.libraryID,
-    jointPath(dir, getPref("syncAttachmentFolder") as string),
+    jointPath(dir, attachmentFolder),
     options.skipSavingImages,
     false,
     NodeMode.direct,
@@ -248,10 +261,22 @@ async function note2latex(
     withYAMLHeader?: boolean;
     cachedYAMLHeader?: Record<string, any>;
     skipSavingImages?: boolean;
+    filename?: string;
   } = {},
 ) {
   const noteStatus = addon.api.sync.getNoteStatus(noteItem.id)!;
   const rehype = await note2rehype(noteStatus.content);
+
+  var attachmentFolder = getPref("syncAttachmentFolder") as string
+  if (options.filename) {
+    var oldDir = new String(attachmentFolder)
+    attachmentFolder = oldDir.replace(/\${filename}/g, options.filename.replace(/\.tex$/gm, '')).valueOf()  // substitute ${filename} & trim '.tex'
+  }
+
+  const hasImage = noteItem.getNote().includes("<img")
+  if (hasImage) {
+    await IOUtils.makeDirectory(jointPath(dir, attachmentFolder));
+  }
 
   const bibString = await processN2LRehypeCitationNodes(
     getN2MRehypeCitationNodes(rehype as HRoot),
@@ -263,7 +288,7 @@ async function note2latex(
   await processN2LRehypeImageNodes(
     getN2MRehypeImageNodes(rehype),
     noteItem.libraryID,
-    jointPath(dir, getPref("syncAttachmentFolder") as string),
+    jointPath(dir, attachmentFolder),
     options.skipSavingImages,
     false,
     NodeMode.direct,
@@ -728,12 +753,14 @@ async function processN2MRehypeImageNodes(
       } else {
         newFile = (await Zotero.File.copyToUnique(oldFile, newAbsPath)).path;
       }
+      var newFileSplits = PathUtils.split(newFile)
+      var newFilename = newFileSplits.pop(), newFileParentFolder = newFileSplits.pop()
       newFile = formatPath(
         absolutePath
           ? newFile
           : jointPath(
-              getPref("syncAttachmentFolder") as string,
-              PathUtils.split(newFile).pop() || "",
+              newFileParentFolder || getPref("syncAttachmentFolder") as string,
+              newFilename || "",
             ),
       );
     } catch (e) {
@@ -1295,12 +1322,14 @@ async function processN2LRehypeImageNodes(
       } else {
         newFile = (await Zotero.File.copyToUnique(oldFile, newAbsPath)).path;
       }
+      var newFileSplits = PathUtils.split(newFile)
+      var newFilename = newFileSplits.pop(), newFileParentFolder = newFileSplits.pop()
       newFile = formatPath(
         absolutePath
           ? newFile
           : jointPath(
-              getPref("syncAttachmentFolder") as string,
-              PathUtils.split(newFile).pop() || "",
+              newFileParentFolder || getPref("syncAttachmentFolder") as string,
+              newFilename || "",
             ),
       );
     } catch (e) {


### PR DESCRIPTION
Add support for `${filename}` representing the corresponding markdown filename of the current note when specifying attachment folder (as in Typora).

As follows, if you export the note to `test.md`, the attachments will be saved to a folder named `test.assets` in the same directory.
<img width="1205" height="947" alt="image" src="https://github.com/user-attachments/assets/3086b0ce-c3db-4c30-98e7-ed1452c5eeed" />

The modifications should only involve syncing markdowns and exporting markdown/latex. 
However, there is a 'Don't overwrite' comment in `processN2MRehypeImageNodes()` and `processN2L...()` of `src\utils\convert.ts`, so I'm not sure if this would harm other functions.