### PR TITLE
fix: annotations2html api converts underline to highlight, fixes #1426

### DIFF
--- a/src/utils/annotation.ts
+++ b/src/utils/annotation.ts
@@ -142,10 +142,10 @@ function serializeAnnotations(
         Zotero.EditorInstanceUtilities,
         annotation.text.trim(),
       );
-      highlightHTML = `<span class="highlight" data-annotation="${encodeURIComponent(
+      highlightHTML = `<span class="${annotation.type}" data-annotation="${encodeURIComponent(
         JSON.stringify(storedAnnotation),
       )}">${text}</span>`;
-      quotedHighlightHTML = `<span class="highlight" data-annotation="${encodeURIComponent(
+      quotedHighlightHTML = `<span class="${annotation.type}" data-annotation="${encodeURIComponent(
         JSON.stringify(storedAnnotation),
       )}">${Zotero.getString(
         "punctuation.openingQMark",


### PR DESCRIPTION
Follows https://github.com/windingwind/zotero-better-notes/commit/43a74a013b24651e6aca38ea0fdc4c4f9fde9352