### PR TITLE
chore: allow disabling ctrl+slash, resolve #1472

### DIFF
--- a/src/extras/editor/magicKey.ts
+++ b/src/extras/editor/magicKey.ts
@@ -18,6 +18,7 @@ interface MagicKeyOptions {
   openAttachment?: () => void;
   canOpenAttachment?: () => boolean;
   enable?: boolean;
+  enableShortcut?: boolean;
 }
 
 interface MagicCommand {
@@ -303,6 +304,7 @@ class PluginState {
     const isMac =
       typeof navigator != "undefined" ? /Mac/.test(navigator.platform) : false;
     if (
+      this.options.enableShortcut &&
       ((isMac && event.metaKey) || (!isMac && event.ctrlKey)) &&
       event.key === "/"
     ) {

--- a/src/utils/editor.ts
+++ b/src/utils/editor.ts
@@ -575,6 +575,7 @@ function initEditorPlugins(editor: Zotero.EditorInstance) {
               );
             },
             enable: getPref("editor.useMagicKey") as boolean,
+            enableShortcut: getPref("editor.useMagicKeyShortcut") as boolean,
           },
           markdownPaste: {
             enable: getPref("editor.useMarkdownPaste") as boolean,


### PR DESCRIPTION
The shortcut `ctrl+/` was enabled by default in previous versions and cannot be disabled. We introduced the disabled checkbox in the settings panel as a hint.

Now, if we make this checkbox configurable, the `Ctrl+/` functionality will no longer be disabled — even if the user disables the shortcut.

This PR allows users to disable the `Ctrl+/` functionality.