### PR TITLE
feat(menu): add openNoteAsBNWindow context menu for Note items

### DIFF
--- a/addon/locale/de/addon.ftl
+++ b/addon/locale/de/addon.ftl
@@ -69,8 +69,8 @@ workspace-emptyWorkspaceGuideOpen = Wähle eine Notiz zum Öffnen
 workspace-emptyWorkspaceGuideOr = oder
 workspace-emptyWorkspaceGuideCreate = Erstelle eine neue Notiz
 
-editor-toolbar-settings-openAsTab = Notiz in neuem Tab öffnen
-editor-toolbar-settings-openAsWindow = Notiz in neuem BN-Fenster öffnen
+editor-toolbar-settings-openAsTab = Notiz in neues Tab öffnen
+editor-toolbar-settings-openAsWindow = Notiz in neues BN-Fenster öffnen
 editor-toolbar-settings-showInLibrary = In Bibliothek anzeigen
 editor-toolbar-settings-insertTemplate = Vorlage einsetzen
 editor-toolbar-settings-refreshTemplates = Inhalt aus Vorlage aktualisieren

--- a/addon/locale/de/mainWindow.ftl
+++ b/addon/locale/de/mainWindow.ftl
@@ -20,3 +20,5 @@ menuAddNote-newTemplateItemNote =
 
 menuTab-moveNewWindow =
     .label = In neues BN-Fenster verschieben
+menu-openNoteAsBNWindow =
+    .label = Notiz in neues BN-Fenster öffnen

--- a/addon/locale/en-US/mainWindow.ftl
+++ b/addon/locale/en-US/mainWindow.ftl
@@ -20,3 +20,5 @@ menuAddNote-newTemplateItemNote =
 
 menuTab-moveNewWindow =
     .label = Move to BN New Window
+menu-openNoteAsBNWindow =
+    .label = Open Note in BN New Window

--- a/addon/locale/it-IT/mainWindow.ftl
+++ b/addon/locale/it-IT/mainWindow.ftl
@@ -20,3 +20,5 @@ menuAddNote-newTemplateItemNote =
 
 menuTab-moveNewWindow =
     .label = Move to BN New Window
+menu-openNoteAsBNWindow =
+    .label = Apri Nota in nuova finestra di BN

--- a/addon/locale/ru-RU/mainWindow.ftl
+++ b/addon/locale/ru-RU/mainWindow.ftl
@@ -20,3 +20,5 @@ menuAddNote-newTemplateItemNote =
 
 menuTab-moveNewWindow =
     .label = Move to BN New Window
+menu-openNoteAsBNWindow =
+    .label = Open Заметка в BN новом окне

--- a/addon/locale/tr-TR/mainWindow.ftl
+++ b/addon/locale/tr-TR/mainWindow.ftl
@@ -20,3 +20,5 @@ menuAddNote-newTemplateItemNote =
 
 menuTab-moveNewWindow =
     .label = Move to BN New Window
+menu-openNoteAsBNWindow =
+    .label = Notu BN Yeni Pencereinde Aç

--- a/addon/locale/zh-CN/mainWindow.ftl
+++ b/addon/locale/zh-CN/mainWindow.ftl
@@ -20,3 +20,5 @@ menuAddNote-newTemplateItemNote =
 
 menuTab-moveNewWindow =
     .label = 移动到 BN 新窗口
+menu-openNoteAsBNWindow =
+    .label = 打开笔记到 BN 新窗口

--- a/src/hooks.ts
+++ b/src/hooks.ts
@@ -37,7 +37,6 @@ import { waitUtilAsync } from "./utils/wait";
 import { initSyncList } from "./modules/sync/api";
 import { getFocusedWindow } from "./utils/window";
 import { registerNoteRelation } from "./modules/workspace/relation";
-import { getPref, setPref } from "./utils/prefs";
 import { closeRelationServer } from "./utils/relation";
 import { registerNoteLinkSection } from "./modules/workspace/link";
 import { showUserGuide } from "./modules/userGuide";

--- a/src/modules/menu.ts
+++ b/src/modules/menu.ts
@@ -147,4 +147,28 @@ export function registerMenus() {
       },
     ],
   });
+
+  Zotero.MenuManager.registerMenu({
+    menuID: `${config.addonRef}-openNoteAsBNWindow`,
+    pluginID: config.addonID,
+    target: "main/library/item",
+    menus: [
+      {
+        menuType: "menuitem",
+        l10nID: `${config.addonRef}-menu-openNoteAsBNWindow`,
+        icon: `chrome://${config.addonRef}/content/icons/favicon.png`,
+        onShowing: (_, context) => {
+          context.setVisible(!!context.items?.every((item) => item.isNote()));
+        },
+        onCommand: (_, context) => {
+          if (!context.items?.length) {
+            return;
+          }
+          addon.hooks.onOpenNote(context.items[0].id, "window", {
+            forceTakeover: true,
+          });
+        },
+      },
+    ],
+  });
 }

--- a/typings/i10n.d.ts
+++ b/typings/i10n.d.ts
@@ -109,6 +109,7 @@ export type FluentMessageId =
   | 'markdown-autoFilename'
   | 'markdown-autoSync'
   | 'markdown-withYAMLHeader'
+  | 'menu-openNoteAsBNWindow'
   | 'menuAddNote-importMD'
   | 'menuAddNote-newTemplateItemNote'
   | 'menuAddNote-newTemplateStandaloneNote'


### PR DESCRIPTION
- Allow to open Note As BN Window by right-clicking in the library window, which maybe more convenient. A potential workaround for enabling wide-mode and BN features prior to the official introduction of native wide/comfortable layout prefs.