### PR TITLE
fix: math block magicKey, fixes #1535

### DIFF
--- a/src/extras/editor/magicKey.ts
+++ b/src/extras/editor/magicKey.ts
@@ -1,4 +1,10 @@
-import { EditorState, Plugin, PluginKey, Transaction } from "prosemirror-state";
+import {
+  EditorState,
+  NodeSelection,
+  Plugin,
+  PluginKey,
+  Transaction,
+} from "prosemirror-state";
 
 import { Popup } from "./popup";
 import { formatMessage } from "./editorStrings";
@@ -633,6 +639,55 @@ class PluginState {
     }
 
     this._closePopup();
+
+    if (command.messageId === "mathBlock") {
+      setTimeout(() => {
+        this._activateSelectedNodeEditor("math_display");
+      }, 0);
+    }
+  }
+
+  _activateSelectedNodeEditor(nodeTypeName: string) {
+    const view = _currentEditorInstance._editorCore.view;
+    const { selection } = view.state;
+    let nodeDOM: HTMLElement | null = null;
+
+    if (
+      selection instanceof NodeSelection &&
+      selection.node.type.name === nodeTypeName
+    ) {
+      nodeDOM = view.nodeDOM(selection.from) as HTMLElement | null;
+    }
+
+    if (!nodeDOM) {
+      nodeDOM =
+        (document.querySelector(
+          ".ProseMirror-selectednode",
+        ) as HTMLElement | null) || null;
+    }
+
+    if (!nodeDOM) {
+      return;
+    }
+
+    const target =
+      (nodeDOM.querySelector(
+        'textarea, input, [contenteditable="true"]',
+      ) as HTMLElement | null) || nodeDOM;
+
+    try {
+      view.focus();
+      target.dispatchEvent(
+        new MouseEvent("click", {
+          bubbles: true,
+          cancelable: true,
+          view: window,
+        }),
+      );
+      target.focus();
+    } catch (error) {
+      console.warn("BN: Failed to activate selected math block", error);
+    }
   }
 
   removeInputSlash(state: EditorState) {

--- a/src/extras/editor/magicKey.ts
+++ b/src/extras/editor/magicKey.ts
@@ -202,6 +202,9 @@ class PluginState {
       searchParts: ["mb", "mathBlock"],
       command: (state) => {
         getPlugin()?.math_display.run();
+        setTimeout(() => {
+          this._activateSelectedNodeEditor("math_display");
+        }, 0);
       },
     },
     {
@@ -639,12 +642,6 @@ class PluginState {
     }
 
     this._closePopup();
-
-    if (command.messageId === "mathBlock") {
-      setTimeout(() => {
-        this._activateSelectedNodeEditor("math_display");
-      }, 0);
-    }
   }
 
   _activateSelectedNodeEditor(nodeTypeName: string) {


### PR DESCRIPTION
Address: #1535
实测使用magicKey激活math block后，必须手动点击一下math block光标区域才能正常输入，否则输入行为将替换掉整个math block，导致无法正常输入公式
此PR在`math_display.run();`运行后，模拟单击该区域，使可以正常输入公式