### PR TITLE
feat(menu): add export notes menu for collections

### DIFF
--- a/addon/locale/de/mainWindow.ftl
+++ b/addon/locale/de/mainWindow.ftl
@@ -18,6 +18,9 @@ menuAddNote-newTemplateStandaloneNote =
 menuAddNote-newTemplateItemNote =
     .label = Neue Eintrags-Notiz aus Vorlage
 
+menuCollection-exportNotes =
+    .label = Export Notes in Collection...
+
 menuTab-moveNewWindow =
     .label = In neues BN-Fenster verschieben
 menu-openNoteAsBNWindow =

--- a/addon/locale/en-US/mainWindow.ftl
+++ b/addon/locale/en-US/mainWindow.ftl
@@ -18,6 +18,9 @@ menuAddNote-newTemplateStandaloneNote =
 menuAddNote-newTemplateItemNote =
     .label = New Item Note from Template
 
+menuCollection-exportNotes =
+    .label = Export Notes in Collection...
+
 menuTab-moveNewWindow =
     .label = Move to BN New Window
 menu-openNoteAsBNWindow =

--- a/addon/locale/it-IT/mainWindow.ftl
+++ b/addon/locale/it-IT/mainWindow.ftl
@@ -18,6 +18,9 @@ menuAddNote-newTemplateStandaloneNote =
 menuAddNote-newTemplateItemNote =
     .label = Nuova Nota Elemento da Template
 
+menuCollection-exportNotes =
+    .label = Export Notes in Collection...
+
 menuTab-moveNewWindow =
     .label = Move to BN New Window
 menu-openNoteAsBNWindow =

--- a/addon/locale/ru-RU/mainWindow.ftl
+++ b/addon/locale/ru-RU/mainWindow.ftl
@@ -18,6 +18,9 @@ menuAddNote-newTemplateStandaloneNote =
 menuAddNote-newTemplateItemNote =
     .label = Новая заметка элемента из шаблона
 
+menuCollection-exportNotes =
+    .label = Export Notes in Collection...
+
 menuTab-moveNewWindow =
     .label = Move to BN New Window
 menu-openNoteAsBNWindow =

--- a/addon/locale/tr-TR/mainWindow.ftl
+++ b/addon/locale/tr-TR/mainWindow.ftl
@@ -18,6 +18,9 @@ menuAddNote-newTemplateStandaloneNote =
 menuAddNote-newTemplateItemNote =
     .label = Şablondan Yeni Öğe Notu
 
+menuCollection-exportNotes =
+    .label = Export Notes in Collection...
+
 menuTab-moveNewWindow =
     .label = Move to BN New Window
 menu-openNoteAsBNWindow =

--- a/addon/locale/zh-CN/mainWindow.ftl
+++ b/addon/locale/zh-CN/mainWindow.ftl
@@ -18,6 +18,9 @@ menuAddNote-newTemplateStandaloneNote =
 menuAddNote-newTemplateItemNote =
     .label = 从模板新建条目笔记
 
+menuCollection-exportNotes =
+    .label = 导出分类中的笔记...
+
 menuTab-moveNewWindow =
     .label = 移动到 BN 新窗口
 menu-openNoteAsBNWindow =

--- a/src/modules/menu.ts
+++ b/src/modules/menu.ts
@@ -83,6 +83,32 @@ export function registerMenus() {
   });
 
   Zotero.MenuManager.registerMenu({
+    menuID: `${config.addonRef}-menuCollectionExportNotes`,
+    pluginID: config.addonID,
+    target: "main/library/collection",
+    menus: [
+      {
+        menuType: "menuitem",
+        l10nID: `${config.addonRef}-menuCollection-exportNotes`,
+        icon: `chrome://${config.addonRef}/content/icons/favicon.png`,
+        onShowing: (_, context) => {
+          context.setVisible(context.collectionTreeRow?.type === "collection");
+        },
+        onCommand: (_, context) => {
+          const collection = context.collectionTreeRow
+            ?.ref as Zotero.Collection | undefined;
+          if (!collection) {
+            return;
+          }
+          addon.hooks.onShowExportNoteOptions(
+            collection.getChildItems(true, false),
+          );
+        },
+      },
+    ],
+  });
+
+  Zotero.MenuManager.registerMenu({
     menuID: `${config.addonRef}-menuHelp`,
     pluginID: config.addonID,
     target: "main/menubar/help",

--- a/typings/i10n.d.ts
+++ b/typings/i10n.d.ts
@@ -113,6 +113,7 @@ export type FluentMessageId =
   | 'menuAddNote-importMD'
   | 'menuAddNote-newTemplateItemNote'
   | 'menuAddNote-newTemplateStandaloneNote'
+  | 'menuCollection-exportNotes'
   | 'menuEditor-copy'
   | 'menuEditor-copyLine'
   | 'menuEditor-copySection'


### PR DESCRIPTION
## Summary

This adds a Better Notes export entry to the collection context menu. When a user right-clicks a Zotero collection, they can export notes from items directly inside that collection using the existing Better Notes export dialog.

The implementation reuses the existing export flow, so users can choose Markdown, Word, PDF, FreeMind, Zotero Note, or LaTeX from the same dialog as regular note export.

## Motivation

Many workflows now involve collecting papers in a Zotero collection and exporting their notes for reading, summarization, or processing with AI tools. Previously, selecting a collection or the regular items inside it did not provide a direct way to export their child notes with Better Notes. Users had to manually locate and select the notes themselves.

## Notes

- This exports notes from direct items in the selected collection only; subcollections are not traversed.
- The menu item is shown only for regular Zotero collections, and existing item export behavior is unchanged.
- Existing batch export behavior may show one `Note Saved to ...` notification per exported note. A follow-up could add an optional quiet/batch mode and show a single summary notification, but this PR leaves that out to avoid changing broader export API behavior.