### PR TITLE
Fix three Zotero 10 editor-init regressions silently breaking note features (#1579)

### DIFF
--- a/src/extras/editor/plugins.ts
+++ b/src/extras/editor/plugins.ts
@@ -22,10 +22,24 @@ function initPlugins(options: {
     plugins = initLinkPreviewPlugin(plugins, options.linkPreview);
   if (options.markdownPaste.enable) plugins = initMarkdownPastePlugin(plugins);
   plugins = initMagicKeyPlugin(plugins, options.magicKey);
+  // Zotero 10's bundled note-editor already registers a `tableColumnResizing`
+  // plugin in the base editor state. ProseMirror's `reconfigure` rejects two
+  // plugins sharing the same `PluginKey`, so adding our custom
+  // `columnResizing` on top throws — and the throw aborts `reconfigure`,
+  // which means `linkPreview` / `magicKey` / `markdownPaste` are never
+  // installed and the in-editor hover-preview, magic key, and markdown
+  // paste features silently stop working (see issue #1579).
+  //
+  // Strip any pre-existing `tableColumnResizing` plugin from the inherited
+  // list so our replacement wins, mirroring how the upstream note-editor
+  // build composes the resize plugin in.
+  const filteredPlugins = plugins.filter(
+    (p: any) => p?.spec?.key?.key !== "tableColumnResizing$1",
+  );
   // Collect all plugins and reconfigure the state only once
   const newState = core.view.state.reconfigure({
     plugins: [
-      ...plugins,
+      ...filteredPlugins,
       columnResizing({
         cellMinWidth: 80,
         handleWidth: 5,
@@ -33,7 +47,16 @@ function initPlugins(options: {
     ],
   });
 
-  initNodeViews(core.view);
+  // Zotero 10's `TableView` constructor now requires an `editorView`
+  // argument; calling the older 0-arg form throws. The throw aborts
+  // `initPlugins` before `updateState` runs, so the same silent breakage
+  // applies. Swallow the failure here — node-view registration is not
+  // load-bearing for hover-preview / magic key / markdown paste.
+  try {
+    initNodeViews(core.view);
+  } catch (e) {
+    console.warn("[BetterNotes] initNodeViews failed:", e);
+  }
 
   core.view.updateState(newState);
 }

--- a/src/modules/patches/noteEditor.ts
+++ b/src/modules/patches/noteEditor.ts
@@ -108,7 +108,9 @@ export function patchNoteEditorCE(win: _ZoteroTypes.MainWindow) {
 }
 
 async function updateExistingNoteTabs(win: _ZoteroTypes.MainWindow) {
-  const tabs = win.Zotero_Tabs._tabs;
+  // Snapshot the live `_tabs` array. Without this, the reopened tabs we
+  // append below get re-iterated by the loop and the takeover recurses.
+  const tabs = [...win.Zotero_Tabs._tabs];
 
   for (const tab of tabs) {
     if (!tab.type.startsWith("note")) {
@@ -121,7 +123,26 @@ async function updateExistingNoteTabs(win: _ZoteroTypes.MainWindow) {
       continue;
     }
 
-    const currentIndex = tabs.indexOf(tab);
+    // Wait for the editor to fully initialize before closing the tab. On
+    // Zotero 10, session-restored note tabs reach `type === "note"`
+    // before their editor instance's `_initPromise` resolves. Closing
+    // mid-init triggers `unregisterEditorInstance(this)` against a
+    // torn-down iframe and produces "can't access dead object" / "tab is
+    // undefined" cascades that leave the reopened tab blank — most
+    // visible when more than one note tab is session-restored (see issue
+    // #1579).
+    try {
+      const editor = Zotero.Notes._editorInstances.find(
+        (e) => e && (e as any)._tabID === tab.id,
+      ) as any;
+      if (editor && editor._initPromise) {
+        await editor._initPromise;
+      }
+    } catch (e) {
+      // Initialization errors are non-fatal here; still take over.
+    }
+
+    const currentIndex = win.Zotero_Tabs._tabs.indexOf(tab);
     const isSelected = win.Zotero_Tabs.selectedID === tab.id ? true : false;
 
     win.Zotero_Tabs.close(tab.id);

--- a/src/utils/str.ts
+++ b/src/utils/str.ts
@@ -40,6 +40,26 @@ export function formatPath(path: string, suffix: string = "") {
 }
 
 export async function getFileContent(path: string) {
+  // Zotero 10's `Zotero.File.getContentsAsync` throws NS_ERROR_FAILURE
+  // inside `xpcom/http.js:33` when passed a `chrome:`, `resource:`,
+  // `jar:` or `file:` URI: the URI parser accesses `.username`, and these
+  // schemes have no userinfo component. The bundled plugin URI we use to
+  // load `editorScript.js` is a `jar:file://.../*.xpi!/...` form on an
+  // installed XPI, so this path fails on every Zotero 10 install and
+  // aborts editor-script injection before the `<script>` tag is appended
+  // — silently killing hover-preview, magic key, markdown paste, image
+  // preview, and the in-editor toolbar (see issue #1579).
+  //
+  // Use `fetch()` for URI-shaped paths (it accepts chrome / resource /
+  // jar / file fine in the privileged context) and keep the original
+  // `getContentsAsync` for OS file paths.
+  if (typeof path === "string" && /^(chrome|resource|file|jar):/.test(path)) {
+    const res = await fetch(path);
+    if (!res.ok) {
+      throw new Error(`getFileContent(${path}) failed: ${res.status}`);
+    }
+    return await res.text();
+  }
   const contentOrXHR = await Zotero.File.getContentsAsync(path);
   const content =
     typeof contentOrXHR === "string"


### PR DESCRIPTION
Closes #1579 (or at least the editor-init half of it — see below).

On Zotero 10 betas, three independent regressions inside Better Notes 3.0.7's editor-init path silently break the in-editor features. None of them log a visible error; the editor just renders but the affected features stop working. Each is a small, surgical fix.

## 1. `getFileContent` throws on the bundled `editorScript.js` URI

`Zotero.File.getContentsAsync` in Zotero 10 throws `NS_ERROR_FAILURE` for any `chrome:` / `resource:` / `jar:` / `file:` URI — the URI parser at `xpcom/http.js:33` accesses `.username`, and those schemes have no userinfo component. The URI we read `editorScript.js` from on an installed XPI is `jar:file://.../Knowledge4Zotero@windingwind.com.xpi!/...`, so this fails on every Zotero 10 install. `injectEditorScripts` aborts before the `<script>` tag is appended, `BetterNotesEditorAPI` is never defined on the editor iframe, and **hover-preview / magic key / markdown paste / image preview / in-editor toolbar all silently break**.

Fix: detect URI-shaped paths and fall back to `fetch()` — it accepts these schemes in the privileged context. OS file paths keep the original code path.

## 2. `initPlugins` aborts on a duplicate ProseMirror plugin key + a `TableView` signature change

Zotero 10's bundled note-editor now registers its own `tableColumnResizing` plugin (keyed `tableColumnResizing$1`) in the base editor state. ProseMirror's `reconfigure` rejects two plugins sharing the same `PluginKey`, so adding the custom `columnResizing` on top throws. The throw aborts the entire `reconfigure`, which means `linkPreview` / `magicKey` / `markdownPaste` never make it into the active plugin list, even when they wouldn't have collided.

Separately, Zotero 10's `TableView` constructor now requires an `editorView` argument; the older 0-arg call inside `initNodeViews` throws and aborts `initPlugins` before `updateState` runs — same silent breakage.

Fix: filter the inherited `tableColumnResizing` key out of the plugin list before reconfiguring (so the BN replacement still wins), and wrap `initNodeViews(core.view)` in a try/catch with a `console.warn`. Node-view registration isn't load-bearing for the affected features.

## 3. `updateExistingNoteTabs` close-reopen race on session restore

Two compounding bugs during the session-restore takeover:

- The loop reads `win.Zotero_Tabs._tabs` live, so the tabs reopened by `Zotero.Notes.open` get re-iterated and the takeover recurses.
- Session-restored note tabs reach `type === \"note\"` before their editor instance's `_initPromise` resolves. Closing mid-init triggers `unregisterEditorInstance(this)` against a torn-down iframe and produces \"can't access dead object\" / \"tab is undefined\" cascades, leaving the reopened tab blank. Most visible when more than one note tab is session-restored: with two note tabs open at shutdown, the focused one comes back empty.

Fix: snapshot `_tabs` with a spread before iterating, then look up the editor instance by `_tabID === tab.id` and await its `_initPromise` (in a try/catch — init errors don't block the takeover) before `Zotero_Tabs.close`.

## Tested against

Zotero 10.0-beta on Windows. I confirmed via a small test matrix that all three fixes are independently necessary:

| Variant         | Hover preview | 1 note tab restore | 2 note tabs restore |
| --------------- | ------------- | ------------------ | ------------------- |
| Stock 3.0.7     | ✗             | mostly ✗           | ✗                   |
| Patch 3 only    | ✗             | depends            | ✗                   |
| Patches 1+2     | ✓             | ✓                  | ✗ (focused blank)   |
| All three       | ✓             | ✓                  | ✓                   |

`tsc --noEmit` passes on the fork.

## Out of scope

Issue #1579 also lists a few side-effects (e.g. the broken-link visual state on note-to-note links). Those weren't reproducible separately once the editor-init path was restored, so I left them alone — happy to look further if anything stays broken on top of these fixes.