### PR TITLE
fix(sync): only parse Markdown front matter at document start

### DIFF
--- a/src/modules/sync/api.ts
+++ b/src/modules/sync/api.ts
@@ -109,8 +109,7 @@ function getSyncStatus(noteId?: number): SyncStatus {
 }
 
 function getMDStatusFromContent(contentRaw: string): MDStatus {
-  contentRaw = contentRaw.replace(/\r\n/g, "\n");
-  const result = contentRaw.match(/^---\n(.*\n)+?---$/gm);
+  contentRaw = contentRaw.replace(/^\uFEFF/, "").replace(/\r\n?/g, "\n");
   const ret: MDStatus = {
     meta: { $version: -1 },
     content: contentRaw,
@@ -118,14 +117,70 @@ function getMDStatusFromContent(contentRaw: string): MDStatus {
     filename: "",
     lastmodify: new Date(0),
   };
-  if (result) {
-    const yaml = result[0].replace(/---/g, "");
-    ret.content = contentRaw.slice(result[0].length);
-    try {
-      ret.meta = YAML.parse(yaml);
-    } catch (e) {
-      ztoolkit.log(e);
+
+  const openingFence = contentRaw.match(/^---[ \t]*\n/);
+  if (!openingFence) {
+    return ret;
+  }
+
+  const yamlStart = openingFence[0].length;
+  let lineStart = yamlStart;
+  let yamlEnd = -1;
+  let contentStart = -1;
+  while (lineStart <= contentRaw.length) {
+    const nextLineBreak = contentRaw.indexOf("\n", lineStart);
+    const lineEnd = nextLineBreak === -1 ? contentRaw.length : nextLineBreak;
+    if (/^---[ \t]*$/.test(contentRaw.slice(lineStart, lineEnd))) {
+      yamlEnd = lineStart;
+      contentStart = lineEnd;
+      break;
     }
+    if (nextLineBreak === -1) {
+      break;
+    }
+    lineStart = nextLineBreak + 1;
+  }
+  if (yamlEnd === -1) {
+    return ret;
+  }
+
+  const yaml = contentRaw.slice(yamlStart, yamlEnd);
+  try {
+    const isEmptyMapping = yaml
+      .split("\n")
+      .every((line) => /^[ \t]*(?:#.*)?$/.test(line));
+    const parsed: unknown = isEmptyMapping ? {} : YAML.parse(yaml);
+    if (
+      typeof parsed !== "object" ||
+      parsed === null ||
+      Array.isArray(parsed)
+    ) {
+      return ret;
+    }
+
+    const meta: Record<string, unknown> = {
+      ...(parsed as Record<string, unknown>),
+    };
+    const hasOwn = Object.prototype.hasOwnProperty;
+    if (
+      (hasOwn.call(meta, "$version") &&
+        (typeof meta.$version !== "number" ||
+          !Number.isFinite(meta.$version))) ||
+      (hasOwn.call(meta, "$libraryID") &&
+        (typeof meta.$libraryID !== "number" ||
+          !Number.isFinite(meta.$libraryID))) ||
+      (hasOwn.call(meta, "$itemKey") && typeof meta.$itemKey !== "string")
+    ) {
+      return ret;
+    }
+    if (!hasOwn.call(meta, "$version")) {
+      meta.$version = -1;
+    }
+
+    ret.meta = meta as MDStatus["meta"];
+    ret.content = contentRaw.slice(contentStart);
+  } catch (e) {
+    ztoolkit.log(e);
   }
   return ret;
 }

--- a/src/modules/sync/api.ts
+++ b/src/modules/sync/api.ts
@@ -109,7 +109,8 @@ function getSyncStatus(noteId?: number): SyncStatus {
 }
 
 function getMDStatusFromContent(contentRaw: string): MDStatus {
-  contentRaw = contentRaw.replace(/^\uFEFF/, "").replace(/\r\n?/g, "\n");
+  contentRaw = contentRaw.replace(/\r\n/g, "\n");
+  const result = contentRaw.match(/^---\n(.*\n)+?---$/gm);
   const ret: MDStatus = {
     meta: { $version: -1 },
     content: contentRaw,
@@ -117,70 +118,14 @@ function getMDStatusFromContent(contentRaw: string): MDStatus {
     filename: "",
     lastmodify: new Date(0),
   };
-
-  const openingFence = contentRaw.match(/^---[ \t]*\n/);
-  if (!openingFence) {
-    return ret;
-  }
-
-  const yamlStart = openingFence[0].length;
-  let lineStart = yamlStart;
-  let yamlEnd = -1;
-  let contentStart = -1;
-  while (lineStart <= contentRaw.length) {
-    const nextLineBreak = contentRaw.indexOf("\n", lineStart);
-    const lineEnd = nextLineBreak === -1 ? contentRaw.length : nextLineBreak;
-    if (/^---[ \t]*$/.test(contentRaw.slice(lineStart, lineEnd))) {
-      yamlEnd = lineStart;
-      contentStart = lineEnd;
-      break;
+  if (result && contentRaw.startsWith(result[0])) {
+    const yaml = result[0].replace(/---/g, "");
+    ret.content = contentRaw.slice(result[0].length);
+    try {
+      ret.meta = YAML.parse(yaml);
+    } catch (e) {
+      ztoolkit.log(e);
     }
-    if (nextLineBreak === -1) {
-      break;
-    }
-    lineStart = nextLineBreak + 1;
-  }
-  if (yamlEnd === -1) {
-    return ret;
-  }
-
-  const yaml = contentRaw.slice(yamlStart, yamlEnd);
-  try {
-    const isEmptyMapping = yaml
-      .split("\n")
-      .every((line) => /^[ \t]*(?:#.*)?$/.test(line));
-    const parsed: unknown = isEmptyMapping ? {} : YAML.parse(yaml);
-    if (
-      typeof parsed !== "object" ||
-      parsed === null ||
-      Array.isArray(parsed)
-    ) {
-      return ret;
-    }
-
-    const meta: Record<string, unknown> = {
-      ...(parsed as Record<string, unknown>),
-    };
-    const hasOwn = Object.prototype.hasOwnProperty;
-    if (
-      (hasOwn.call(meta, "$version") &&
-        (typeof meta.$version !== "number" ||
-          !Number.isFinite(meta.$version))) ||
-      (hasOwn.call(meta, "$libraryID") &&
-        (typeof meta.$libraryID !== "number" ||
-          !Number.isFinite(meta.$libraryID))) ||
-      (hasOwn.call(meta, "$itemKey") && typeof meta.$itemKey !== "string")
-    ) {
-      return ret;
-    }
-    if (!hasOwn.call(meta, "$version")) {
-      meta.$version = -1;
-    }
-
-    ret.meta = meta as MDStatus["meta"];
-    ret.content = contentRaw.slice(contentStart);
-  } catch (e) {
-    ztoolkit.log(e);
   }
   return ret;
 }

--- a/test/tests/sync-mdStatus.spec.ts
+++ b/test/tests/sync-mdStatus.spec.ts
@@ -1,0 +1,274 @@
+import { getAddon } from "../utils/global";
+
+describe("Sync - Markdown status parsing", function () {
+  const addon = getAddon();
+
+  type ParsedStatus = ReturnType<typeof addon.api.sync.getMDStatusFromContent>;
+
+  function parseWithoutThrow(input: string) {
+    let status: ParsedStatus | undefined;
+    expect(() => {
+      status = addon.api.sync.getMDStatusFromContent(input);
+    }).not.to.throw();
+    if (!status) {
+      throw new Error("getMDStatusFromContent returned no status");
+    }
+    return status;
+  }
+
+  function expectFixedEnvelope(status: ParsedStatus) {
+    expect(status).to.have.all.keys(
+      "meta",
+      "content",
+      "filedir",
+      "filename",
+      "lastmodify",
+    );
+    expect(status.filedir).to.equal("");
+    expect(status.filename).to.equal("");
+    expect(status.lastmodify.getTime()).to.equal(0);
+  }
+
+  function expectFallback(input: string, expectedContent = input) {
+    const status = parseWithoutThrow(input);
+    expectFixedEnvelope(status);
+    expect(status.meta).to.deep.equal({ $version: -1 });
+    expect(status.content).to.equal(expectedContent);
+  }
+
+  it("preserves headerless Markdown with multiple fence-like body lines", function () {
+    const input = [
+      "# Document",
+      "",
+      "A thematic break follows.",
+      "---",
+      "This is still body content.",
+      "---",
+      "",
+      "```yaml",
+      "---",
+      "value: a---b",
+      "---",
+      "```",
+      "",
+      "| left | right |",
+      "| --- | --- |",
+      "| a | b |",
+      "",
+    ].join("\n");
+
+    expectFallback(input);
+  });
+
+  const nonOpeningFenceCases = [
+    {
+      name: "a leading blank line",
+      input: "\n---\n$version: 2\n---\nbody",
+    },
+    {
+      name: "leading spaces",
+      input: "  ---\n$version: 2\n---\nbody",
+    },
+    {
+      name: "non-whitespace on the opening fence line",
+      input: "--- not-front-matter\n$version: 2\n---\nbody",
+    },
+  ];
+
+  for (const testCase of nonOpeningFenceCases) {
+    it(`does not treat front matter after ${testCase.name} as a header`, function () {
+      expectFallback(testCase.input);
+    });
+  }
+
+  const acceptedHeaderCases = [
+    {
+      name: "an opening fence at the absolute beginning",
+      input: "---\n$version: 7\n$libraryID: 4\n$itemKey: ABC123\n---\nbody",
+      expectedMeta: {
+        $version: 7,
+        $libraryID: 4,
+        $itemKey: "ABC123",
+      },
+      expectedContent: "\nbody",
+    },
+    {
+      name: "a single leading BOM",
+      input: "\uFEFF---\n$version: 3\n---\nbody",
+      expectedMeta: { $version: 3 },
+      expectedContent: "\nbody",
+    },
+    {
+      name: "an empty header",
+      input: "---\n---\nbody",
+      expectedMeta: { $version: -1 },
+      expectedContent: "\nbody",
+    },
+    {
+      name: "a whitespace-only header",
+      input: "---\n \t\n\t  \n---\nbody",
+      expectedMeta: { $version: -1 },
+      expectedContent: "\nbody",
+    },
+    {
+      name: "a comment-only header",
+      input:
+        "---\n# first comment\n   # indented comment\n\t# tabbed comment\n---\nbody",
+      expectedMeta: { $version: -1 },
+      expectedContent: "\nbody",
+    },
+    {
+      name: "spaces and tabs after both fences",
+      input: "--- \t\n$version: 9\n---\t  \nbody",
+      expectedMeta: { $version: 9 },
+      expectedContent: "\nbody",
+    },
+    {
+      name: "a closing front-matter fence exactly at EOF",
+      input: "---\n$version: 10\n$itemKey: EOF123\n---",
+      expectedMeta: { $version: 10, $itemKey: "EOF123" },
+      expectedContent: "",
+    },
+  ];
+
+  for (const testCase of acceptedHeaderCases) {
+    it(`parses ${testCase.name}`, function () {
+      const status = parseWithoutThrow(testCase.input);
+      expectFixedEnvelope(status);
+      expect(status.meta).to.deep.equal(testCase.expectedMeta);
+      expect(status.content).to.equal(testCase.expectedContent);
+    });
+  }
+
+  it("preserves unknown YAML values and defaults a missing version", function () {
+    const input = [
+      "---",
+      "$libraryID: 23",
+      "$itemKey: ITEM1234",
+      "marker: a---b",
+      "enabled: true",
+      "count: 3",
+      "nothing: null",
+      "tags:",
+      "  - alpha",
+      "  - beta",
+      "nested:",
+      "  level: 2",
+      "---",
+      "body",
+    ].join("\n");
+
+    const status = parseWithoutThrow(input);
+    expectFixedEnvelope(status);
+    expect(status.meta).to.deep.equal({
+      $libraryID: 23,
+      $itemKey: "ITEM1234",
+      marker: "a---b",
+      enabled: true,
+      count: 3,
+      nothing: null,
+      tags: ["alpha", "beta"],
+      nested: { level: 2 },
+      $version: -1,
+    });
+    expect(status.content).to.equal("\nbody");
+  });
+
+  it("returns a plain object containing only own enumerable YAML properties", function () {
+    const input = [
+      "---",
+      "__proto__:",
+      "  inherited: unsafe",
+      "own: safe",
+      "---",
+      "body",
+    ].join("\n");
+
+    const status = parseWithoutThrow(input);
+    expectFixedEnvelope(status);
+    const meta = status.meta as NonNullable<ParsedStatus["meta"]> &
+      Record<string, unknown>;
+    const ordinaryMeta = parseWithoutThrow("---\nordinary: mapping\n---\nbody")
+      .meta as NonNullable<ParsedStatus["meta"]>;
+    expect(Object.getPrototypeOf(meta)).to.equal(
+      Object.getPrototypeOf(ordinaryMeta),
+    );
+    expect(Object.prototype.hasOwnProperty.call(meta, "inherited")).to.equal(
+      false,
+    );
+    expect(meta.inherited).to.equal(undefined);
+    expect(meta.own).to.equal("safe");
+    expect(meta.$version).to.equal(-1);
+    expect(status.content).to.equal("\nbody");
+  });
+
+  it("keeps all whitespace after a successful closing fence", function () {
+    const input = "---\n$version: 4\n---\n\n  padded body  \n\n";
+    const status = parseWithoutThrow(input);
+
+    expectFixedEnvelope(status);
+    expect(status.meta).to.deep.equal({ $version: 4 });
+    expect(status.content).to.equal("\n\n  padded body  \n\n");
+  });
+
+  it("normalizes CRLF and isolated CR throughout the document", function () {
+    const input =
+      "---\r\n$version: 6\r$libraryID: 8\r\n---\r\nline 1\rline 2\r\n";
+    const status = parseWithoutThrow(input);
+
+    expectFixedEnvelope(status);
+    expect(status.meta).to.deep.equal({ $version: 6, $libraryID: 8 });
+    expect(status.content).to.equal("\nline 1\nline 2\n");
+  });
+
+  const invalidDocumentCases = [
+    {
+      name: "an unclosed header",
+      input: "---\n$version: 1\nbody",
+      expectedContent: "---\n$version: 1\nbody",
+    },
+    {
+      name: "invalid YAML",
+      input: "---\r\nbroken: [one, two\r\n---\rbody\r\n",
+      expectedContent: "---\nbroken: [one, two\n---\nbody\n",
+    },
+    {
+      name: "a scalar YAML root",
+      input: "---\nplain scalar\n---\nbody",
+      expectedContent: "---\nplain scalar\n---\nbody",
+    },
+    {
+      name: "an array YAML root",
+      input: "---\n- one\n- two\n---\nbody",
+      expectedContent: "---\n- one\n- two\n---\nbody",
+    },
+    {
+      name: "a null YAML root",
+      input: "---\nnull\n---\nbody",
+      expectedContent: "---\nnull\n---\nbody",
+    },
+  ];
+
+  for (const testCase of invalidDocumentCases) {
+    it(`falls back without truncating for ${testCase.name}`, function () {
+      expectFallback(testCase.input, testCase.expectedContent);
+    });
+  }
+
+  const invalidKnownFieldCases = [
+    { name: "$version has the wrong type", yaml: "$version: '7'" },
+    { name: "$libraryID has the wrong type", yaml: "$libraryID: '2'" },
+    { name: "$itemKey has the wrong type", yaml: "$itemKey: 123" },
+    { name: "$version is NaN", yaml: "$version: .NaN" },
+    { name: "$version is infinite", yaml: "$version: .Inf" },
+    { name: "$libraryID is NaN", yaml: "$libraryID: .NaN" },
+    { name: "$libraryID is infinite", yaml: "$libraryID: .Inf" },
+  ];
+
+  for (const testCase of invalidKnownFieldCases) {
+    it(`falls back when ${testCase.name}`, function () {
+      const input = ["---", testCase.yaml, "---", "body"].join("\n");
+      expectFallback(input);
+    });
+  }
+});

--- a/test/tests/sync-mdStatus.spec.ts
+++ b/test/tests/sync-mdStatus.spec.ts
@@ -3,272 +3,38 @@ import { getAddon } from "../utils/global";
 describe("Sync - Markdown status parsing", function () {
   const addon = getAddon();
 
-  type ParsedStatus = ReturnType<typeof addon.api.sync.getMDStatusFromContent>;
-
-  function parseWithoutThrow(input: string) {
-    let status: ParsedStatus | undefined;
-    expect(() => {
-      status = addon.api.sync.getMDStatusFromContent(input);
-    }).not.to.throw();
-    if (!status) {
-      throw new Error("getMDStatusFromContent returned no status");
-    }
-    return status;
-  }
-
-  function expectFixedEnvelope(status: ParsedStatus) {
-    expect(status).to.have.all.keys(
-      "meta",
-      "content",
-      "filedir",
-      "filename",
-      "lastmodify",
-    );
-    expect(status.filedir).to.equal("");
-    expect(status.filename).to.equal("");
-    expect(status.lastmodify.getTime()).to.equal(0);
-  }
-
-  function expectFallback(input: string, expectedContent = input) {
-    const status = parseWithoutThrow(input);
-    expectFixedEnvelope(status);
-    expect(status.meta).to.deep.equal({ $version: -1 });
-    expect(status.content).to.equal(expectedContent);
-  }
-
-  it("preserves headerless Markdown with multiple fence-like body lines", function () {
+  it("preserves content before a YAML-like block in the body", function () {
     const input = [
       "# Document",
       "",
-      "A thematic break follows.",
+      "Intro before the horizontal rules.",
       "---",
-      "This is still body content.",
+      "body: content",
       "---",
-      "",
-      "```yaml",
-      "---",
-      "value: a---b",
-      "---",
-      "```",
-      "",
-      "| left | right |",
-      "| --- | --- |",
-      "| a | b |",
-      "",
+      "Tail after the horizontal rules.",
     ].join("\n");
 
-    expectFallback(input);
+    const status = addon.api.sync.getMDStatusFromContent(input);
+    expect(status.meta).to.deep.equal({ $version: -1 });
+    expect(status.content).to.equal(input);
   });
 
-  const nonOpeningFenceCases = [
-    {
-      name: "a leading blank line",
-      input: "\n---\n$version: 2\n---\nbody",
-    },
-    {
-      name: "leading spaces",
-      input: "  ---\n$version: 2\n---\nbody",
-    },
-    {
-      name: "non-whitespace on the opening fence line",
-      input: "--- not-front-matter\n$version: 2\n---\nbody",
-    },
-  ];
-
-  for (const testCase of nonOpeningFenceCases) {
-    it(`does not treat front matter after ${testCase.name} as a header`, function () {
-      expectFallback(testCase.input);
-    });
-  }
-
-  const acceptedHeaderCases = [
-    {
-      name: "an opening fence at the absolute beginning",
-      input: "---\n$version: 7\n$libraryID: 4\n$itemKey: ABC123\n---\nbody",
-      expectedMeta: {
-        $version: 7,
-        $libraryID: 4,
-        $itemKey: "ABC123",
-      },
-      expectedContent: "\nbody",
-    },
-    {
-      name: "a single leading BOM",
-      input: "\uFEFF---\n$version: 3\n---\nbody",
-      expectedMeta: { $version: 3 },
-      expectedContent: "\nbody",
-    },
-    {
-      name: "an empty header",
-      input: "---\n---\nbody",
-      expectedMeta: { $version: -1 },
-      expectedContent: "\nbody",
-    },
-    {
-      name: "a whitespace-only header",
-      input: "---\n \t\n\t  \n---\nbody",
-      expectedMeta: { $version: -1 },
-      expectedContent: "\nbody",
-    },
-    {
-      name: "a comment-only header",
-      input:
-        "---\n# first comment\n   # indented comment\n\t# tabbed comment\n---\nbody",
-      expectedMeta: { $version: -1 },
-      expectedContent: "\nbody",
-    },
-    {
-      name: "spaces and tabs after both fences",
-      input: "--- \t\n$version: 9\n---\t  \nbody",
-      expectedMeta: { $version: 9 },
-      expectedContent: "\nbody",
-    },
-    {
-      name: "a closing front-matter fence exactly at EOF",
-      input: "---\n$version: 10\n$itemKey: EOF123\n---",
-      expectedMeta: { $version: 10, $itemKey: "EOF123" },
-      expectedContent: "",
-    },
-  ];
-
-  for (const testCase of acceptedHeaderCases) {
-    it(`parses ${testCase.name}`, function () {
-      const status = parseWithoutThrow(testCase.input);
-      expectFixedEnvelope(status);
-      expect(status.meta).to.deep.equal(testCase.expectedMeta);
-      expect(status.content).to.equal(testCase.expectedContent);
-    });
-  }
-
-  it("preserves unknown YAML values and defaults a missing version", function () {
+  it("parses YAML front matter at the document start", function () {
     const input = [
       "---",
-      "$libraryID: 23",
-      "$itemKey: ITEM1234",
-      "marker: a---b",
-      "enabled: true",
-      "count: 3",
-      "nothing: null",
-      "tags:",
-      "  - alpha",
-      "  - beta",
-      "nested:",
-      "  level: 2",
+      "$version: 7",
+      "$libraryID: 4",
+      "$itemKey: ABC123",
       "---",
       "body",
     ].join("\n");
 
-    const status = parseWithoutThrow(input);
-    expectFixedEnvelope(status);
+    const status = addon.api.sync.getMDStatusFromContent(input);
     expect(status.meta).to.deep.equal({
-      $libraryID: 23,
-      $itemKey: "ITEM1234",
-      marker: "a---b",
-      enabled: true,
-      count: 3,
-      nothing: null,
-      tags: ["alpha", "beta"],
-      nested: { level: 2 },
-      $version: -1,
+      $version: 7,
+      $libraryID: 4,
+      $itemKey: "ABC123",
     });
     expect(status.content).to.equal("\nbody");
   });
-
-  it("returns a plain object containing only own enumerable YAML properties", function () {
-    const input = [
-      "---",
-      "__proto__:",
-      "  inherited: unsafe",
-      "own: safe",
-      "---",
-      "body",
-    ].join("\n");
-
-    const status = parseWithoutThrow(input);
-    expectFixedEnvelope(status);
-    const meta = status.meta as NonNullable<ParsedStatus["meta"]> &
-      Record<string, unknown>;
-    const ordinaryMeta = parseWithoutThrow("---\nordinary: mapping\n---\nbody")
-      .meta as NonNullable<ParsedStatus["meta"]>;
-    expect(Object.getPrototypeOf(meta)).to.equal(
-      Object.getPrototypeOf(ordinaryMeta),
-    );
-    expect(Object.prototype.hasOwnProperty.call(meta, "inherited")).to.equal(
-      false,
-    );
-    expect(meta.inherited).to.equal(undefined);
-    expect(meta.own).to.equal("safe");
-    expect(meta.$version).to.equal(-1);
-    expect(status.content).to.equal("\nbody");
-  });
-
-  it("keeps all whitespace after a successful closing fence", function () {
-    const input = "---\n$version: 4\n---\n\n  padded body  \n\n";
-    const status = parseWithoutThrow(input);
-
-    expectFixedEnvelope(status);
-    expect(status.meta).to.deep.equal({ $version: 4 });
-    expect(status.content).to.equal("\n\n  padded body  \n\n");
-  });
-
-  it("normalizes CRLF and isolated CR throughout the document", function () {
-    const input =
-      "---\r\n$version: 6\r$libraryID: 8\r\n---\r\nline 1\rline 2\r\n";
-    const status = parseWithoutThrow(input);
-
-    expectFixedEnvelope(status);
-    expect(status.meta).to.deep.equal({ $version: 6, $libraryID: 8 });
-    expect(status.content).to.equal("\nline 1\nline 2\n");
-  });
-
-  const invalidDocumentCases = [
-    {
-      name: "an unclosed header",
-      input: "---\n$version: 1\nbody",
-      expectedContent: "---\n$version: 1\nbody",
-    },
-    {
-      name: "invalid YAML",
-      input: "---\r\nbroken: [one, two\r\n---\rbody\r\n",
-      expectedContent: "---\nbroken: [one, two\n---\nbody\n",
-    },
-    {
-      name: "a scalar YAML root",
-      input: "---\nplain scalar\n---\nbody",
-      expectedContent: "---\nplain scalar\n---\nbody",
-    },
-    {
-      name: "an array YAML root",
-      input: "---\n- one\n- two\n---\nbody",
-      expectedContent: "---\n- one\n- two\n---\nbody",
-    },
-    {
-      name: "a null YAML root",
-      input: "---\nnull\n---\nbody",
-      expectedContent: "---\nnull\n---\nbody",
-    },
-  ];
-
-  for (const testCase of invalidDocumentCases) {
-    it(`falls back without truncating for ${testCase.name}`, function () {
-      expectFallback(testCase.input, testCase.expectedContent);
-    });
-  }
-
-  const invalidKnownFieldCases = [
-    { name: "$version has the wrong type", yaml: "$version: '7'" },
-    { name: "$libraryID has the wrong type", yaml: "$libraryID: '2'" },
-    { name: "$itemKey has the wrong type", yaml: "$itemKey: 123" },
-    { name: "$version is NaN", yaml: "$version: .NaN" },
-    { name: "$version is infinite", yaml: "$version: .Inf" },
-    { name: "$libraryID is NaN", yaml: "$libraryID: .NaN" },
-    { name: "$libraryID is infinite", yaml: "$libraryID: .Inf" },
-  ];
-
-  for (const testCase of invalidKnownFieldCases) {
-    it(`falls back when ${testCase.name}`, function () {
-      const input = ["---", testCase.yaml, "---", "body"].join("\n");
-      expectFallback(input);
-    });
-  }
 });


### PR DESCRIPTION
> [!IMPORTANT]
> **AI-assisted contribution disclosure:** This fix was implemented by OpenAI Codex under the contributor's direction. The contributor reproduced the original truncation behavior and reviewed the resulting patch.
>
> **Scope and risk:** This revision intentionally keeps the existing regular expression, YAML parser, and newline behavior. It only rejects a match when document content precedes it. This avoids introducing new parsing semantics, while retaining existing limitations such as leading-BOM/blank-line handling and malformed-front-matter behavior.

## Problem

`getMDStatusFromContent` searches globally for a block delimited by `---`. In a headerless Markdown document, horizontal rules in the body can therefore become the first match. The old code then slices from the beginning by the matched block's length, dropping an unrelated prefix.

## Change

Keep the existing parser and accept its first match only when the document starts with that match:

```ts
if (result && contentRaw.startsWith(result[0])) {
```

The production-code diff is one condition. Two focused tests cover the reported regression and confirm that valid front matter at the document start is still parsed.

## Validation

- `npx tsc --noEmit`
- `npx prettier --check src/modules/sync/api.ts test/tests/sync-mdStatus.spec.ts`
- `npx eslint src/modules/sync/api.ts test/tests/sync-mdStatus.spec.ts --ext .ts`
- `git diff --check`
- `npm run build` (production XPI, version `3.3.0-beta.6`)
- exact-regex check against a 39,570-character related report containing 13 body matches: the first match begins at offset 679, and the new guard preserves all 39,570 characters

`npm test` on the latest beta.6 base currently stops at the unrelated existing test `follows the default-mode and toggle-button preferences`: beta.6 changed `editor.showMarkdownToggle` to `false`, while that test still expects the toggle to be visible by default. With only that upstream test temporarily skipped locally, the remaining suite completed with **50 passed**, including both tests added here. The skip was restored and is not part of this PR.

Related to #1600. The symptom overlaps, but this PR does not assume that every reported approximately-32k truncation case has the same root cause.
